### PR TITLE
ci: update npm token to use github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
                   GIT_AUTHOR_NAME: Whitebox Bot
                   GIT_AUTHOR_EMAIL: whitebox-bot@whitebox.com
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
               run: npm run semantic-release


### PR DESCRIPTION
Updating NPM_TOKEN to use GITHUB_TOKEN in generate-api gh workflow since we are using gh npm packages.